### PR TITLE
Setup pre-commit style checking

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run lint

--- a/client/.eslintrc.cjs
+++ b/client/.eslintrc.cjs
@@ -1,0 +1,31 @@
+module.exports = {
+  env: {
+    node: true,
+    browser: true,
+    es2021: true,
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:react/jsx-runtime',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+  ],
+  overrides: [],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['react', '@typescript-eslint', 'prettier'],
+  rules: {},
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+};

--- a/client/.prettierrc
+++ b/client/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,15 @@
   "devDependencies": {
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
+    "@typescript-eslint/eslint-plugin": "^5.40.0",
+    "@typescript-eslint/parser": "^5.40.0",
     "@vitejs/plugin-react": "^2.1.0",
+    "eslint": "^8.25.0",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-react": "^7.31.10",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "prettier": "^2.7.1",
     "typescript": "^4.6.4",
     "vite": "^3.1.0"
   }

--- a/client/package.json
+++ b/client/package.json
@@ -12,8 +12,7 @@
   },
   "lint-staged": {
     "src/**/*.+(ts|tsx)": [
-      "eslint --fix",
-      "tsc-files --noEmit"
+      "eslint --fix"
     ],
     "src/**/*.{js,jsx,ts,tsx,json,css}": [
       "prettier --write"

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,18 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint:staged": "lint-staged"
+  },
+  "lint-staged": {
+    "src/**/*.+(ts|tsx)": [
+      "eslint --fix",
+      "tsc-files --noEmit"
+    ],
+    "src/**/*.{js,jsx,ts,tsx,json,css}": [
+      "prettier --write"
+    ],
+    "*.js": "eslint --cache --fix"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.8.6",
@@ -29,6 +40,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.31.10",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "lint-staged": "^13.0.3",
     "prettier": "^2.7.1",
     "typescript": "^4.6.4",
     "vite": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "install": "cd client && npm install && cd ../server && npm install"
+    "install": "cd client && npm install && cd ../server && npm install",
+    "prepare": "husky install",
+    "lint": "npm-run-all lint:backend lint:frontend",
+    "lint:backend": "cd server && npm run lint:staged",
+    "lint:frontend": "cd client && npm run lint:staged"
   },
   "repository": {
     "type": "git",
@@ -17,5 +21,9 @@
   "bugs": {
     "url": "https://github.com/chingu-voyages/v41-bears-team-20/issues"
   },
-  "homepage": "https://github.com/chingu-voyages/v41-bears-team-20#readme"
+  "homepage": "https://github.com/chingu-voyages/v41-bears-team-20#readme",
+  "devDependencies": {
+    "husky": "^8.0.1",
+    "npm-run-all": "^4.1.5"
+  }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -23,8 +23,7 @@
   },
   "lint-staged": {
     "src/**/*.+(ts)": [
-      "eslint --fix",
-      "tsc-files --noEmit"
+      "eslint --fix"
     ],
     "src/**/*.{ts,json}": [
       "prettier --write"

--- a/server/package.json
+++ b/server/package.json
@@ -14,11 +14,21 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "lint:staged": "lint-staged",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json"
+  },
+  "lint-staged": {
+    "src/**/*.+(ts)": [
+      "eslint --fix",
+      "tsc-files --noEmit"
+    ],
+    "src/**/*.{ts,json}": [
+      "prettier --write"
+    ]
   },
   "dependencies": {
     "@nestjs/common": "^9.0.0",
@@ -46,6 +56,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "28.1.3",
+    "lint-staged": "^13.0.3",
     "prettier": "^2.3.2",
     "source-map-support": "^0.5.20",
     "supertest": "^6.1.3",


### PR DESCRIPTION
Closes #18 

**WHAT**
- Setup ESLint & Prettier on frontend
- Setup lint-staged on frontend and backend
- Setup husky pre-commit hook to run lint-staged so all committed files are checked against ESlint and Prettier rules

**WHY**
- Enforcing consistent code styles is good practice
- Preventing style violations from being committed to the code base keeps code quality high

**HOW**
- run `npm install` on root directory
- Write & commit code
- Linters should be triggered and fix style violations or stop code commits if there is eslint/prettier error

**POTENTIAL ISSUES**
- Had to disable/ ignore tsconfig rules because I don't have enough knowledge on how to set them up properly
- Only checked husky/linting on backend, not frontend
- husky may or may not work properly for people on windows

**Resources**
- https://javifm.com/en/blog/monorepo-simple-starter-workflow/

**Demo**

https://user-images.githubusercontent.com/14286113/195432877-0ec1165e-41e7-47a2-905b-45ac1f8184c8.mp4


