### PR TITLE
Profile endpoint CRUD operations creation

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -27,10 +27,12 @@ model User {
 }
 
 model Profile {
-  id     Int    @id @default(autoincrement())
-  age Int 
-  bio    String?
-  contactInfo String
+  id          Int    @id @default(autoincrement())
+  age         Int? 
+  bio         String?
+  subjects    String?
+  rate        Int?
+  phone       String?
   user   User   @relation(fields: [userId], references: [id])
   userId Int    @unique
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -35,7 +35,7 @@ model Profile {
   phone       String?
   city        String?
   state       String?
-  user        User   @relation(fields: [userId], references: [id])
+  user        User   @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId      Int    @unique
 }
 

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -13,17 +13,17 @@ datasource db {
 }
 
 model User {
-  id      Int      @id @default(autoincrement())
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id          Int      @id @default(autoincrement())
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
   
-  firstName String 
-  lastName String
-  email    String @unique 
-  password String
+  firstName   String 
+  lastName    String
+  email       String @unique 
+  password    String
   // post POST[]
-  profile Profile?
-  role Role @default(STUDENT)
+  profile     Profile?
+  role        Role @default(STUDENT)
 }
 
 model Profile {
@@ -31,10 +31,12 @@ model Profile {
   age         Int? 
   bio         String?
   subjects    String?
-  rate        Int?
+  rate        Decimal?
   phone       String?
-  user   User   @relation(fields: [userId], references: [id])
-  userId Int    @unique
+  city        String?
+  state       String?
+  user        User   @relation(fields: [userId], references: [id])
+  userId      Int    @unique
 }
 
 enum Role {

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -4,12 +4,14 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PrismaModule } from './prisma/prisma.module';
 import { UsersModule } from './users/users.module';
+import { ProfilesModule } from './profiles/profiles.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
     PrismaModule,
     UsersModule,
+    ProfilesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/server/src/profiles/dto/create-profile.dto.ts
+++ b/server/src/profiles/dto/create-profile.dto.ts
@@ -1,0 +1,1 @@
+export class CreateProfileDto {}

--- a/server/src/profiles/dto/create-profile.dto.ts
+++ b/server/src/profiles/dto/create-profile.dto.ts
@@ -1,1 +1,12 @@
-export class CreateProfileDto {}
+import { ApiProperty } from '@nestjs/swagger';
+import { User } from '@prisma/client';
+
+export class CreateProfileDto {
+  age: number;
+
+  bio?: string;
+
+  contactInfo: string;
+
+  user: User;
+}

--- a/server/src/profiles/dto/create-profile.dto.ts
+++ b/server/src/profiles/dto/create-profile.dto.ts
@@ -2,11 +2,27 @@ import { ApiProperty } from '@nestjs/swagger';
 import { User } from '@prisma/client';
 
 export class CreateProfileDto {
-  age: number;
+  @ApiProperty({ required: false, nullable: true })
+  age?: number;
 
+  @ApiProperty({ required: false, nullable: true })
   bio?: string;
 
-  contactInfo: string;
+  @ApiProperty({ required: false, nullable: true })
+  subjects?: string;
 
+  @ApiProperty({ required: false, nullable: true })
+  rate?: number;
+
+  @ApiProperty({ required: false, nullable: true })
+  phone?: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  city?: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  state?: string;
+
+  @ApiProperty()
   user: User;
 }

--- a/server/src/profiles/dto/update-profile.dto.ts
+++ b/server/src/profiles/dto/update-profile.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateProfileDto } from './create-profile.dto';
+
+export class UpdateProfileDto extends PartialType(CreateProfileDto) {}

--- a/server/src/profiles/dto/update-profile.dto.ts
+++ b/server/src/profiles/dto/update-profile.dto.ts
@@ -2,23 +2,23 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateProfileDto {
   @ApiProperty({ required: false, nullable: true })
-  age?: number;
+  age?: number | null;
 
   @ApiProperty({ required: false, nullable: true })
-  bio?: string;
+  bio?: string | null;
 
   @ApiProperty({ required: false, nullable: true })
-  subjects?: string;
+  subjects?: string | null;
 
   @ApiProperty({ required: false, nullable: true })
-  rate?: number;
+  rate?: number | null;
 
   @ApiProperty({ required: false, nullable: true })
-  phone?: string;
+  phone?: string | null;
 
   @ApiProperty({ required: false, nullable: true })
-  city?: string;
+  city?: string | null;
 
   @ApiProperty({ required: false, nullable: true })
-  state?: string;
+  state?: string | null;
 }

--- a/server/src/profiles/dto/update-profile.dto.ts
+++ b/server/src/profiles/dto/update-profile.dto.ts
@@ -1,4 +1,24 @@
-import { PartialType } from '@nestjs/swagger';
-import { CreateProfileDto } from './create-profile.dto';
+import { ApiProperty } from '@nestjs/swagger';
 
-export class UpdateProfileDto extends PartialType(CreateProfileDto) {}
+export class UpdateProfileDto {
+  @ApiProperty({ required: false, nullable: true })
+  age?: number;
+
+  @ApiProperty({ required: false, nullable: true })
+  bio?: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  subjects?: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  rate?: number;
+
+  @ApiProperty({ required: false, nullable: true })
+  phone?: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  city?: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  state?: string;
+}

--- a/server/src/profiles/entities/profile.entity.ts
+++ b/server/src/profiles/entities/profile.entity.ts
@@ -1,0 +1,1 @@
+export class Profile {}

--- a/server/src/profiles/entities/profile.entity.ts
+++ b/server/src/profiles/entities/profile.entity.ts
@@ -1,1 +1,31 @@
-export class Profile {}
+import { Profile, Prisma } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ProfileEntity implements Profile {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty({ required: false, nullable: true })
+  age: number | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  bio: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  subjects: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  rate: Prisma.Decimal | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  phone: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  city: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  state: string | null;
+
+  @ApiProperty()
+  userId: number;
+}

--- a/server/src/profiles/entities/profileCreatedResponse.entity.ts
+++ b/server/src/profiles/entities/profileCreatedResponse.entity.ts
@@ -1,0 +1,10 @@
+import { ProfileEntity } from './profile.entity';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ProfileCreatedResponseEntity {
+  @ApiProperty({ default: 201 })
+  statusCode: number;
+
+  @ApiProperty()
+  data: ProfileEntity;
+}

--- a/server/src/profiles/entities/profileOkResponse.entity.ts
+++ b/server/src/profiles/entities/profileOkResponse.entity.ts
@@ -1,0 +1,18 @@
+import { ProfileEntity } from './profile.entity';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ProfileOkResponseEntity {
+  @ApiProperty({ default: 200 })
+  statusCode: number;
+
+  @ApiProperty()
+  data: ProfileEntity;
+}
+
+export class ProfileOkResponseEntityArray {
+  @ApiProperty({ default: 200 })
+  statusCode: number;
+
+  @ApiProperty({ type: [ProfileEntity] })
+  data: ProfileEntity[];
+}

--- a/server/src/profiles/profiles.controller.spec.ts
+++ b/server/src/profiles/profiles.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProfilesController } from './profiles.controller';
+import { ProfilesService } from './profiles.service';
+
+describe('ProfilesController', () => {
+  let controller: ProfilesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProfilesController],
+      providers: [ProfilesService],
+    }).compile();
+
+    controller = module.get<ProfilesController>(ProfilesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/server/src/profiles/profiles.controller.spec.ts
+++ b/server/src/profiles/profiles.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ProfilesController } from './profiles.controller';
 import { ProfilesService } from './profiles.service';
+import { PrismaService } from './../prisma/prisma.service';
 
 describe('ProfilesController', () => {
   let controller: ProfilesController;
@@ -8,7 +9,7 @@ describe('ProfilesController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ProfilesController],
-      providers: [ProfilesService],
+      providers: [ProfilesService, PrismaService],
     }).compile();
 
     controller = module.get<ProfilesController>(ProfilesController);

--- a/server/src/profiles/profiles.controller.ts
+++ b/server/src/profiles/profiles.controller.ts
@@ -1,0 +1,42 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
+import { ProfilesService } from './profiles.service';
+import { CreateProfileDto } from './dto/create-profile.dto';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+
+@Controller('profiles')
+export class ProfilesController {
+  constructor(private readonly profilesService: ProfilesService) {}
+
+  @Post()
+  create(@Body() createProfileDto: CreateProfileDto) {
+    return this.profilesService.create(createProfileDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.profilesService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.profilesService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateProfileDto: UpdateProfileDto) {
+    return this.profilesService.update(+id, updateProfileDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.profilesService.remove(+id);
+  }
+}

--- a/server/src/profiles/profiles.controller.ts
+++ b/server/src/profiles/profiles.controller.ts
@@ -16,13 +16,20 @@ import { ProfilesService } from './profiles.service';
 import { CreateProfileDto } from './dto/create-profile.dto';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 import { ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { ProfileCreatedResponseEntity } from './entities/profileCreatedResponse.entity';
+import {
+  ProfileOkResponseEntity,
+  ProfileOkResponseEntityArray,
+} from './entities/profileOkResponse.entity';
 
 @Controller('profiles')
 @ApiTags('profiles')
 export class ProfilesController {
   constructor(private readonly profilesService: ProfilesService) {}
 
+  // profile creation should be done through user creation
   @Post()
+  @ApiCreatedResponse({ type: ProfileCreatedResponseEntity })
   async create(
     @Body() createProfileDto: CreateProfileDto,
     @Res() res: Response,
@@ -36,6 +43,7 @@ export class ProfilesController {
   }
 
   @Get()
+  @ApiOkResponse({ type: ProfileOkResponseEntityArray })
   async findAll(@Res() res: Response) {
     const profiles = await this.profilesService.findAll();
 
@@ -50,6 +58,7 @@ export class ProfilesController {
   }
 
   @Get(':id')
+  @ApiOkResponse({ type: ProfileOkResponseEntity })
   async findOne(@Param('id', ParseIntPipe) id: number, @Res() res: Response) {
     const profile = await this.profilesService.findOne(id);
 
@@ -66,6 +75,7 @@ export class ProfilesController {
   }
 
   @Patch(':id')
+  @ApiOkResponse({ type: ProfileOkResponseEntity })
   async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateProfileDto: UpdateProfileDto,
@@ -82,7 +92,9 @@ export class ProfilesController {
     });
   }
 
+  // profile deletion should be done through user deletion
   @Delete(':id')
+  @ApiOkResponse({ type: ProfileOkResponseEntity })
   async remove(@Param('id', ParseIntPipe) id: number, @Res() res: Response) {
     const removedProfile = await this.profilesService.remove(id);
 

--- a/server/src/profiles/profiles.controller.ts
+++ b/server/src/profiles/profiles.controller.ts
@@ -10,8 +10,10 @@ import {
 import { ProfilesService } from './profiles.service';
 import { CreateProfileDto } from './dto/create-profile.dto';
 import { UpdateProfileDto } from './dto/update-profile.dto';
+import { ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
 
 @Controller('profiles')
+@ApiTags('profiles')
 export class ProfilesController {
   constructor(private readonly profilesService: ProfilesService) {}
 

--- a/server/src/profiles/profiles.module.ts
+++ b/server/src/profiles/profiles.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ProfilesService } from './profiles.service';
+import { ProfilesController } from './profiles.controller';
+
+@Module({
+  controllers: [ProfilesController],
+  providers: [ProfilesService],
+})
+export class ProfilesModule {}

--- a/server/src/profiles/profiles.module.ts
+++ b/server/src/profiles/profiles.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ProfilesService } from './profiles.service';
 import { ProfilesController } from './profiles.controller';
+import { PrismaModule } from './../prisma/prisma.module';
 
 @Module({
   controllers: [ProfilesController],
   providers: [ProfilesService],
+  imports: [PrismaModule],
+  exports: [ProfilesService],
 })
 export class ProfilesModule {}

--- a/server/src/profiles/profiles.service.spec.ts
+++ b/server/src/profiles/profiles.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProfilesService } from './profiles.service';
+
+describe('ProfilesService', () => {
+  let service: ProfilesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProfilesService],
+    }).compile();
+
+    service = module.get<ProfilesService>(ProfilesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/server/src/profiles/profiles.service.spec.ts
+++ b/server/src/profiles/profiles.service.spec.ts
@@ -1,12 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ProfilesService } from './profiles.service';
+import { PrismaService } from './../prisma/prisma.service';
 
 describe('ProfilesService', () => {
   let service: ProfilesService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ProfilesService],
+      providers: [ProfilesService, PrismaService],
     }).compile();
 
     service = module.get<ProfilesService>(ProfilesService);

--- a/server/src/profiles/profiles.service.ts
+++ b/server/src/profiles/profiles.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateProfileDto } from './dto/create-profile.dto';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+
+@Injectable()
+export class ProfilesService {
+  create(createProfileDto: CreateProfileDto) {
+    return 'This action adds a new profile';
+  }
+
+  findAll() {
+    return `This action returns all profiles`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} profile`;
+  }
+
+  update(id: number, updateProfileDto: UpdateProfileDto) {
+    return `This action updates a #${id} profile`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} profile`;
+  }
+}

--- a/server/src/profiles/profiles.service.ts
+++ b/server/src/profiles/profiles.service.ts
@@ -7,23 +7,30 @@ import { PrismaService } from './../prisma/prisma.service';
 export class ProfilesService {
   constructor(private prisma: PrismaService) {}
 
-  create(createProfileDto: CreateProfileDto) {
-    return this.prisma.profile.create({ data: createProfileDto });
+  async create(createProfileDto: CreateProfileDto) {
+    return await this.prisma.profile.create({ data: createProfileDto });
   }
 
-  findAll() {
-    return `This action returns all profiles`;
+  async findAll() {
+    return await this.prisma.profile.findMany({ include: { user: true } });
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} profile`;
+  async findOne(id: number) {
+    return await this.prisma.profile.findUnique({
+      where: { userId: id },
+      include: { user: true },
+    });
   }
 
-  update(id: number, updateProfileDto: UpdateProfileDto) {
-    return `This action updates a #${id} profile`;
+  async update(id: number, updateProfileDto: UpdateProfileDto) {
+    return await this.prisma.profile.update({
+      where: { userId: id },
+      data: updateProfileDto,
+      include: { user: true },
+    });
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} profile`;
+  async remove(id: number) {
+    return await this.prisma.profile.delete({ where: { userId: id } });
   }
 }

--- a/server/src/profiles/profiles.service.ts
+++ b/server/src/profiles/profiles.service.ts
@@ -8,7 +8,10 @@ export class ProfilesService {
   constructor(private prisma: PrismaService) {}
 
   async create(createProfileDto: CreateProfileDto) {
-    return await this.prisma.profile.create({ data: createProfileDto });
+    return await this.prisma.profile.create({
+      data: createProfileDto,
+      include: { user: true },
+    });
   }
 
   async findAll() {

--- a/server/src/profiles/profiles.service.ts
+++ b/server/src/profiles/profiles.service.ts
@@ -1,11 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { CreateProfileDto } from './dto/create-profile.dto';
 import { UpdateProfileDto } from './dto/update-profile.dto';
+import { PrismaService } from './../prisma/prisma.service';
 
 @Injectable()
 export class ProfilesService {
+  constructor(private prisma: PrismaService) {}
+
   create(createProfileDto: CreateProfileDto) {
-    return 'This action adds a new profile';
+    return this.prisma.profile.create({ data: createProfileDto });
   }
 
   findAll() {

--- a/server/src/users/users.controller.ts
+++ b/server/src/users/users.controller.ts
@@ -56,21 +56,6 @@ export class UsersController {
     });
   }
 
-  @Get(':id')
-  @ApiOkResponse({ type: UserOkResponseEntity })
-  async findOne(@Param('id', ParseIntPipe) id: number, @Res() res: Response) {
-    const user = await this.usersService.findOne(id);
-
-    if (!user) {
-      throw new NotFoundException(`User with id: ${id} not found`);
-    }
-
-    return res.status(HttpStatus.OK).json({
-      statusCode: HttpStatus.OK,
-      data: user,
-    });
-  }
-
   @Get('students')
   @ApiOkResponse({ type: UserOkResponseEntityArray })
   async findAllStudents(
@@ -104,6 +89,21 @@ export class UsersController {
     return res.status(HttpStatus.OK).json({
       statusCode: HttpStatus.OK,
       data: tutors,
+    });
+  }
+
+  @Get(':id')
+  @ApiOkResponse({ type: UserOkResponseEntity })
+  async findOne(@Param('id', ParseIntPipe) id: number, @Res() res: Response) {
+    const user = await this.usersService.findOne(id);
+
+    if (!user) {
+      throw new NotFoundException(`User with id: ${id} not found`);
+    }
+
+    return res.status(HttpStatus.OK).json({
+      statusCode: HttpStatus.OK,
+      data: user,
     });
   }
 

--- a/server/src/users/users.controller.ts
+++ b/server/src/users/users.controller.ts
@@ -71,6 +71,42 @@ export class UsersController {
     });
   }
 
+  @Get('students')
+  @ApiOkResponse({ type: UserOkResponseEntityArray })
+  async findAllStudents(
+    @Res()
+    res: Response,
+  ) {
+    const students = await this.usersService.findAllStudents();
+
+    if (!students.length) {
+      throw new NotFoundException('No students found');
+    }
+
+    return res.status(HttpStatus.OK).json({
+      statusCode: HttpStatus.OK,
+      data: students,
+    });
+  }
+
+  @Get('tutors')
+  @ApiOkResponse({ type: UserOkResponseEntityArray })
+  async findAllTutors(
+    @Res()
+    res: Response,
+  ) {
+    const tutors = await this.usersService.findAllTutors();
+
+    if (!tutors.length) {
+      throw new NotFoundException('No tutors found');
+    }
+
+    return res.status(HttpStatus.OK).json({
+      statusCode: HttpStatus.OK,
+      data: tutors,
+    });
+  }
+
   @Patch(':id')
   @ApiOkResponse({ type: UserOkResponseEntity })
   async update(

--- a/server/src/users/users.controller.ts
+++ b/server/src/users/users.controller.ts
@@ -40,10 +40,7 @@ export class UsersController {
 
   @Get()
   @ApiOkResponse({ type: UserOkResponseEntityArray })
-  async findAll(
-    @Res()
-    res: Response,
-  ) {
+  async findAll(@Res() res: Response) {
     const users = await this.usersService.findAll();
 
     if (!users.length) {
@@ -58,10 +55,7 @@ export class UsersController {
 
   @Get('students')
   @ApiOkResponse({ type: UserOkResponseEntityArray })
-  async findAllStudents(
-    @Res()
-    res: Response,
-  ) {
+  async findAllStudents(@Res() res: Response) {
     const students = await this.usersService.findAllStudents();
 
     if (!students.length) {
@@ -76,10 +70,7 @@ export class UsersController {
 
   @Get('tutors')
   @ApiOkResponse({ type: UserOkResponseEntityArray })
-  async findAllTutors(
-    @Res()
-    res: Response,
-  ) {
+  async findAllTutors(@Res() res: Response) {
     const tutors = await this.usersService.findAllTutors();
 
     if (!tutors.length) {

--- a/server/src/users/users.controller.ts
+++ b/server/src/users/users.controller.ts
@@ -20,7 +20,7 @@ import {
   UserOkResponseEntity,
   UserOkResponseEntityArray,
 } from './entities/userOkResponse.entity';
-import { UserCreatedResponseEntity } from './entities/UserCreatedResponse.entity';
+import { UserCreatedResponseEntity } from './entities/userCreatedResponse.entity';
 
 @Controller('users')
 @ApiTags('users')

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -54,9 +54,10 @@ export class UsersService {
   }
 
   async remove(id: number) {
-    await this.prisma.profile.delete({ where: { userId: id } });
+    // await this.prisma.profile.delete({ where: { userId: id } });
     return await this.prisma.user.delete({
       where: { id: id },
+      include: { profile: true },
     });
   }
 

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -8,15 +8,39 @@ export class UsersService {
   constructor(private prisma: PrismaService) {}
 
   async create(createUserDto: CreateUserDto) {
-    return await this.prisma.user.create({ data: createUserDto });
+    return await this.prisma.user.create({
+      data: {
+        ...createUserDto,
+        profile: {
+          create: createUserDto.profile,
+        },
+      },
+    });
   }
 
   async findAll() {
-    return await this.prisma.user.findMany();
+    return await this.prisma.user.findMany({ include: { profile: true } });
   }
 
   async findOne(id: number) {
-    return await this.prisma.user.findUnique({ where: { id: id } });
+    return await this.prisma.user.findUnique({
+      where: { id: id },
+      include: { profile: true },
+    });
+  }
+
+  async findAllStudents() {
+    return await this.prisma.user.findMany({
+      where: { role: 'STUDENT' },
+      include: { profile: true },
+    });
+  }
+
+  async findAllTutors() {
+    return await this.prisma.user.findMany({
+      where: { role: 'TUTOR' },
+      include: { profile: true },
+    });
   }
 
   async update(id: number, updateUserDto: UpdateUserDto) {
@@ -30,19 +54,7 @@ export class UsersService {
     return await this.prisma.user.delete({ where: { id: id } });
   }
 
-  async checkUserExists(id: number) {
-    const user = await this.findOne(id);
-    console.log(user);
-
-    if (!user) return false;
-    return true;
-  }
-
-  async checkEmailExists(email: string) {
-    const user = await this.prisma.user.findFirst({ where: { email: email } });
-    console.log(user);
-
-    if (!user) return false;
-    return true;
+  async findUserByEmail(email: string) {
+    return await this.prisma.user.findFirst({ where: { email: email } });
   }
 }

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -15,6 +15,9 @@ export class UsersService {
           create: createUserDto.profile,
         },
       },
+      include: {
+        profile: true,
+      },
     });
   }
 
@@ -51,6 +54,7 @@ export class UsersService {
   }
 
   async remove(id: number) {
+    await this.prisma.profile.delete({ where: { userId: id } });
     return await this.prisma.user.delete({ where: { id: id } });
   }
 

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -55,7 +55,9 @@ export class UsersService {
 
   async remove(id: number) {
     await this.prisma.profile.delete({ where: { userId: id } });
-    return await this.prisma.user.delete({ where: { id: id } });
+    return await this.prisma.user.delete({
+      where: { id: id },
+    });
   }
 
   async findUserByEmail(email: string) {


### PR DESCRIPTION
I've updated our schema to include an expanded selection of fields. All of these are optional. I figure we can use the same profile for both the student and tutor and the front-end will define which fields are filled, rather than dividing the profile between students and tutors. I've also updated the user routes slightly in this PR so that most queries will return the profile as well. When creating a user, a profile is automatically created for them with all fields null. Deleting a user will also automatically delete the user's profile. Querying .../users/students and .../users/tutors will return only the respective role (as an array). I've also changed one of the helper functions used by the auth module: specifically, the findUserByEmail function (renamed from checkEmailExists) which will return the user rather than a boolean if found.  The profile module has also been created, and full CRUD functionality implemented. Note that we should probably not use the create or delete operations as this should be handled when deleting the respective user using the user endpoint instead.